### PR TITLE
env_specific different server for dev and prod

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgxPaginationModule } from 'ngx-pagination';
+import { environment } from './../environments/environment';
 
 // custom
 import { AppComponent } from './app.component';
@@ -18,8 +19,7 @@ import { HeaderComponent } from './header/header.component';
 import { FooterComponent } from './footer/footer.component';
 import { GlobalErrorHandler } from './global-error.handler';
 
-// const apolloServer = 'http://localhost:9000/api/graphql';
-const apolloServer = 'https://apolloserver-demo.herokuapp.com/graphql';
+const apolloServer = environment.apolloServer;
 
 @NgModule({
   declarations: [

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  apolloServer: 'https://apolloserver-demo.herokuapp.com/graphql'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apolloServer: 'http://localhost:9000/api/graphql'
 };
 
 /*


### PR DESCRIPTION
these settings show up in the client anyway. If you really wanted you
could find them, so there is no point in trying to hide the server name.
The only thing about this hard-coded server that does not make sense is
the hostname and that change will happen as soon as the host has been
migrated to our domain